### PR TITLE
Fix for overwriting local output_heads attribute

### DIFF
--- a/transformer_heads/config.py
+++ b/transformer_heads/config.py
@@ -134,7 +134,8 @@ def create_headed_model_config(
             """
             out = cls(output_heads)
             for key, value in base_config.__dict__.items():
-                setattr(out, key, value)
+                if key not in "output_heads":
+                    setattr(out, key, value)
             return out
 
         def to_base_class(self) -> PretrainedConfig:


### PR DESCRIPTION
In case the `base_config` has an attribute `output_heads` the `setattr` overwrites the local `output_heads` in `HeadedConfig`. This is because it comes after instantiating the `HeadConfig` class: 

```
out = cls(output_heads)
for key, value in base_config.__dict__.items():
        setattr(out, key, value)
```

In my case the `output_heads` got overwritten with a dict object and that leads to a downstream error when accessing the `name` attribute via the object field in [model/model.py](https://github.com/center-for-humans-and-machines/transformer-heads/blob/fcfbce17dd0715b946df39c5705394a8f3cd6b90/transformer_heads/model/model.py#L717).

My suggestion to fix is to not copy the `output_heads` attribute at all, since it's already set in the `HeadConfig` constructor.